### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths-ignore: ['.github/**']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SocketSomeone/nestjs-service-template/security/code-scanning/4](https://github.com/SocketSomeone/nestjs-service-template/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only performs basic CI tasks (e.g., installing dependencies, running linting, building, and testing), it does not require write permissions. The `contents: read` permission is sufficient for these operations. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
